### PR TITLE
add MKL linkage fix with mkl_rt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ extensions = [
     Extension("libmqc", sources=sourcefile1,  include_dirs=[np.get_include()], \
         libraries=libs, library_dirs=lib_dirs),
     Extension("libmqcxf", sources=sourcefile2, include_dirs=[np.get_include()]),
-    Extension("libctmqc", sources=sourcefile3, include_dirs=[np.get_include()], \
+    Extension("libctmqc", sources=sourcefile3, include_dirs=[np.get_include()]),
     Extension("libcioverlap", sources=sourcefile4, include_dirs=[np.get_include()], \
         libraries=libs, library_dirs=lib_dirs, extra_compile_args=extra_flags),
     # Electronic propagation in MQC_QED dynamics

--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,13 @@ extensions = [
         libraries=libs, library_dirs=lib_dirs),
     Extension("libmqcxf", sources=sourcefile2, include_dirs=[np.get_include()]),
     Extension("libctmqc", sources=sourcefile3, include_dirs=[np.get_include()], \
-        libraries=libs, library_dirs=lib_dirs),
     Extension("libcioverlap", sources=sourcefile4, include_dirs=[np.get_include()], \
         libraries=libs, library_dirs=lib_dirs, extra_compile_args=extra_flags),
     # Electronic propagation in MQC_QED dynamics
-    Extension("libmqc_qed", sources=sourcefile1_qed, include_dirs=[np.get_include()]),
-    Extension("libmqcxf_qed", sources=sourcefile2_qed, include_dirs=[np.get_include()])
+    Extension("libmqc_qed", sources=sourcefile1_qed, include_dirs=[np.get_include()], \
+        libraries=libs, library_dirs=lib_dirs),
+    Extension("libmqcxf_qed", sources=sourcefile2_qed, include_dirs=[np.get_include()], \
+        libraries=libs, library_dirs=lib_dirs)
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ extensions = [
     Extension("libmqc", sources=sourcefile1,  include_dirs=[np.get_include()], \
         libraries=libs, library_dirs=lib_dirs),
     Extension("libmqcxf", sources=sourcefile2, include_dirs=[np.get_include()]),
-    Extension("libctmqc", sources=sourcefile3, include_dirs=[np.get_include()]),
+    Extension("libctmqc", sources=sourcefile3, include_dirs=[np.get_include()], \
+        libraries=libs, library_dirs=lib_dirs),
     Extension("libcioverlap", sources=sourcefile4, include_dirs=[np.get_include()], \
         libraries=libs, library_dirs=lib_dirs, extra_compile_args=extra_flags),
     # Electronic propagation in MQC_QED dynamics


### PR DESCRIPTION
Previously, linkage to MKL was incomplete. This commit adds mkl_rt and properly links all shared objects.